### PR TITLE
fix(boilerplate): replace hardcoded root.hcl with RootFileName template variable

### DIFF
--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -21,7 +21,7 @@ locals {
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
 generate "provider-mongoatlas" {


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `root.hcl` string with the Go template variable `{{ .RootFileName }}` in `.boilerplate/terragrunt.hcl`
- Allows the boilerplate to support configurable root HCL filenames across different environments and deployments
- Removes a hidden assumption that the root include file is always named `root.hcl`

## Test plan
- [ ] Verify boilerplate renders correctly when `RootFileName` is provided as a template input
- [ ] Verify existing deployments using `root.hcl` continue to work when that value is passed as `RootFileName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)